### PR TITLE
Analytical Tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,13 @@ Changelog
 
 Here's a log of all the changes that have happened to this package.
 
-1.1.0 - Latest
+1.2.0 - 2017-12-25 (Latest)
+
+#### Add
+
+- Added very basic analytical tracking of whom is using this buildpack based on the application domains [James Kirby]
+
+1.1.0 - 2017-08-16
 ------
 
 #### Add

--- a/bin/compile
+++ b/bin/compile
@@ -39,7 +39,6 @@ try:
 
     typekit = Typekit(typeKitId, typeKitApiKey);
     heroku = Heroku(herokuAppName);
-    analytics = Analytics(herokuAppName);
 
     kit = typekit.kit();
 
@@ -48,6 +47,8 @@ try:
 
     herokuAppUrl = heroku.url();
     typeKitDomains = kit['domains'];
+
+    analytics = Analytics(herokuAppUrl);
 
     if herokuAppUrl in typeKitDomains:
         print output.line('The domain "' + herokuAppUrl + '" has already been added into Typekit.');

--- a/bin/compile
+++ b/bin/compile
@@ -15,6 +15,7 @@ sys.path.append(
 import output;
 import env;
 
+from analytics import Analytics;
 from typekit import Typekit;
 from heroku import Heroku;
 
@@ -38,6 +39,7 @@ try:
 
     typekit = Typekit(typeKitId, typeKitApiKey);
     heroku = Heroku(herokuAppName);
+    analytics = Analytics(herokuAppName);
 
     kit = typekit.kit();
 
@@ -59,6 +61,11 @@ try:
 
         print output.line('The domain "' + herokuAppUrl + '" has been added to your Typekit account.');
         print output.line('Your new kit may take a few minutes to be completely distributed across the Typekit network.');
+
+    ##
+    # NB: This is purely to see whom is using the buildpack.
+    ##
+    analytics.ping();
 
 except RuntimeError as e:
 

--- a/bin/release
+++ b/bin/release
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
 
 ##
-# NB: This has not yet been implemented.
+# NB: This is not required.
 ##

--- a/lib/analytics.py
+++ b/lib/analytics.py
@@ -8,7 +8,7 @@ class Analytics():
     def __init__(self, domain):
         self.domain = domain;
         self.service = 'heroku-buildpack-typekit';
-        self.endpoint = 'jedkirby.com';
+        self.endpoint = 'jedkirby-develop-pr-51.herokuapp.com';
 
     ##
     # Create a secure connection.

--- a/lib/analytics.py
+++ b/lib/analytics.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+
+import httplib;
+import json;
+
+class Analytics():
+
+    def __init__(self, domain):
+        self.domain = domain;
+        self.service = 'heroku-buildpack-typekit';
+        self.endpoint = 'jedkirby.com';
+
+    ##
+    # Create a secure connection.
+    #
+    # @return HTTPSConnection
+    ##
+    def connection(self):
+        return httplib.HTTPSConnection(self.endpoint);
+
+    ##
+    # Using the connection, make a request to the API using the correct endpoint.
+    #
+    # @param string method
+    # @param string endpoint
+    # @param string body
+    #
+    # @return bool|object
+    ##
+    def request(self, method, endpoint, body = ''):
+        try :
+            conn = self.connection();
+            conn.request(method, endpoint, body, {});
+            response = conn.getresponse();
+            if response.status != 200:
+                return False;
+            else:
+                return json.loads(
+                    response.read()
+                );
+        finally:
+            conn.close();
+
+    ##
+    # Compile a list of params for the ping to register with the correct application.
+    #
+    # @return string
+    ##
+    def params(self):
+        return ','.join([
+            'domain=' + self.domain,
+            'service=' + self.service
+        ]);
+
+    ##
+    # Ping the usage of the buildback purely
+    # for statistical information.
+    #
+    # @return bool
+    ##
+    def ping(self):
+        response = self.request('POST', '/api/v1/ping', self.params());
+        return True if response else False;


### PR DESCRIPTION
This will enable the very basic analytical tracking of users using the buildpack. It'll only send the app url that's being used, along with a timestamp.